### PR TITLE
add cache for gradle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ jobs:
       with:
         distribution: temurin
         java-version: 11
+        cache: gradle
     - run: |
         chmod +x ./gradlew
         sed -i 's/moduleDescription = "/moduleDescription = "(${{ github.event.inputs.package_name }}) /g' module.gradle


### PR DESCRIPTION
Adding a cache reduces the length by about 1/3.

(although the reduction in length is not very much... It might reduce it by about 40 seconds)