### PR TITLE
HbCI: Perbarui GitHub Actions yang sudah usang ke v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-java@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
       with:
         distribution: temurin
         java-version: 11
@@ -21,7 +21,7 @@ jobs:
         sed -i 's/moduleDescription = "/moduleDescription = "(${{ github.event.inputs.package_name }}) /g' module.gradle
         sed -i "s/com.game.packagename/${{ github.event.inputs.package_name }}/g" module/src/main/cpp/game.h
         ./gradlew :module:assembleRelease
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: zygisk-il2cppdumper
         path: out/magisk_module_release/


### PR DESCRIPTION
Alur kerja build gagal karena penggunaan `actions/upload-artifact: v3` yang sudah tidak digunakan lagi.

Commit ini memperbarui tindakan berikut ke versi utama terbaru (v4) untuk mengatasi masalah dan memastikan kompatibilitas di masa mendatang:
- `actions/checkout`
- `actions/setup-java`
- `actions/upload-artifact` 